### PR TITLE
Publish the .d.ts file for `@babel/types`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ clone-license:
 
 prepublish-build: clean-lib clean-runtime-helpers
 	NODE_ENV=production BABEL_ENV=production STRIP_BABEL_8_FLAG=true $(MAKE) build-bundle
-	$(MAKE) prepublish-build-standalone clone-license
+	$(MAKE) prepublish-build-standalone clone-license prepublish-prepare-dts
 
 prepublish-prepare-dts:
 	$(MAKE) clean-tsconfig
@@ -211,7 +211,6 @@ prepublish:
 	$(MAKE) check-yarn-bug-1882
 	$(MAKE) bootstrap-only
 	$(MAKE) prepublish-build
-	$(MAKE) prepublish-prepare-dts
 	IS_PUBLISH=true $(MAKE) test
 
 new-version:

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ tscheck: generate-tsconfig
 	cp packages/babel-types/src/builders/generated/deprecated.d.ts packages/babel-types/lib/builders/generated/deprecated.d.ts
 	$(YARN) tsc -b .
 
-flow:
+flow: build-flow-typings
 	$(YARN) flow check --strip-root
 
 lint-ci: lint-js-ci lint-ts-ci check-compat-data-ci

--- a/Makefile
+++ b/Makefile
@@ -97,24 +97,13 @@ tscheck: generate-tsconfig
 flow: build-flow-typings
 	$(YARN) flow check --strip-root
 
-lint-ci: lint-js-ci lint-ts-ci check-compat-data-ci
-
-lint-js-ci:
-	$(MAKE) lint-js
-
-lint-ts-ci:
-	$(MAKE) lint-ts
+lint-ci: lint check-compat-data-ci
 
 check-compat-data-ci:
 	$(MAKE) check-compat-data
 
-lint: lint-js lint-ts
-
-lint-js:
+lint:
 	BABEL_ENV=test $(YARN) eslint scripts $(SOURCES) '*.{js,ts}' --format=codeframe --ext .js,.cjs,.mjs,.ts
-
-lint-ts:
-	scripts/lint-ts-typings.sh
 
 fix: fix-json fix-js
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,4 +9,4 @@ coverage:
     patch:
       enabled: false
 ignore:
-  - packages/babel-types/src/*/generated/index.js
+  - packages/babel-types/src/*/generated/*

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "mergeiterator": "^1.2.5",
     "prettier": "^2.0.5",
     "rollup": "^2.26.5",
+    "rollup-plugin-dts": "^2.0.0",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "rollup-plugin-terser": "^7.0.0",
     "test262-stream": "^1.3.0",

--- a/packages/babel-helper-replace-supers/src/index.js
+++ b/packages/babel-helper-replace-supers/src/index.js
@@ -46,7 +46,7 @@ export function skipAllButComputedKey(path: NodePath) {
 // Avoid using `path.scope` here
 export const environmentVisitor = {
   // todo (Babel 8): remove StaticBlock brand checks
-  [`${t.StaticBlock ? "StaticBlock|" : ""}ClassPrivateProperty|TypeAnnotation`](
+  [`${t.staticBlock ? "StaticBlock|" : ""}ClassPrivateProperty|TypeAnnotation`](
     path: NodePath,
   ) {
     path.skip();

--- a/packages/babel-types/scripts/generators/flow.js
+++ b/packages/babel-types/scripts/generators/flow.js
@@ -98,7 +98,7 @@ for (const type in t.NODE_FIELDS) {
   // Flow chokes on super() and import() :/
   if (type !== "Super" && type !== "Import") {
     lines.push(
-      `declare function ${toFunctionName(type)}(${args.join(
+      `declare export function ${toFunctionName(type)}(${args.join(
         ", "
       )}): ${NODE_PREFIX}${type};`
     );
@@ -117,85 +117,90 @@ for (const typeName of t.TYPES) {
   const isDeprecated = !!t.DEPRECATED_KEYS[typeName];
   const realName = isDeprecated ? t.DEPRECATED_KEYS[typeName] : typeName;
 
-  let decl = `declare function is${typeName}(node: ?Object, opts?: ?Object): boolean`;
+  let decl = `declare export function is${typeName}(node: ?Object, opts?: ?Object): boolean`;
   if (t.NODE_FIELDS[realName]) {
     decl += ` %checks (node instanceof ${NODE_PREFIX}${realName})`;
   }
   lines.push(decl);
 
   lines.push(
-    `declare function assert${typeName}(node: ?Object, opts?: ?Object): void`
+    `declare export function assert${typeName}(node: ?Object, opts?: ?Object): void`
   );
 }
 
 lines.push(
+  `declare export var VISITOR_KEYS: { [type: string]: string[] }`,
+
   // assert/
-  `declare function assertNode(obj: any): void`,
+  `declare export function assertNode(obj: any): void`,
 
   // builders/
   // eslint-disable-next-line max-len
-  `declare function createTypeAnnotationBasedOnTypeof(type: 'string' | 'number' | 'undefined' | 'boolean' | 'function' | 'object' | 'symbol'): ${NODE_PREFIX}TypeAnnotation`,
+  `declare export function createTypeAnnotationBasedOnTypeof(type: 'string' | 'number' | 'undefined' | 'boolean' | 'function' | 'object' | 'symbol'): ${NODE_PREFIX}TypeAnnotation`,
   // eslint-disable-next-line max-len
-  `declare function createUnionTypeAnnotation(types: Array<${NODE_PREFIX}FlowType>): ${NODE_PREFIX}UnionTypeAnnotation`,
+  `declare export function createUnionTypeAnnotation(types: Array<${NODE_PREFIX}FlowType>): ${NODE_PREFIX}UnionTypeAnnotation`,
   // eslint-disable-next-line max-len
-  `declare function createFlowUnionType(types: Array<${NODE_PREFIX}FlowType>): ${NODE_PREFIX}UnionTypeAnnotation`,
+  `declare export function createFlowUnionType(types: Array<${NODE_PREFIX}FlowType>): ${NODE_PREFIX}UnionTypeAnnotation`,
   // this smells like "internal API"
   // eslint-disable-next-line max-len
-  `declare function buildChildren(node: { children: Array<${NODE_PREFIX}JSXText | ${NODE_PREFIX}JSXExpressionContainer | ${NODE_PREFIX}JSXSpreadChild | ${NODE_PREFIX}JSXElement | ${NODE_PREFIX}JSXFragment | ${NODE_PREFIX}JSXEmptyExpression> }): Array<${NODE_PREFIX}JSXText | ${NODE_PREFIX}JSXExpressionContainer | ${NODE_PREFIX}JSXSpreadChild | ${NODE_PREFIX}JSXElement | ${NODE_PREFIX}JSXFragment>`,
+  `declare export function buildChildren(node: { children: Array<${NODE_PREFIX}JSXText | ${NODE_PREFIX}JSXExpressionContainer | ${NODE_PREFIX}JSXSpreadChild | ${NODE_PREFIX}JSXElement | ${NODE_PREFIX}JSXFragment | ${NODE_PREFIX}JSXEmptyExpression> }): Array<${NODE_PREFIX}JSXText | ${NODE_PREFIX}JSXExpressionContainer | ${NODE_PREFIX}JSXSpreadChild | ${NODE_PREFIX}JSXElement | ${NODE_PREFIX}JSXFragment>`,
 
   // clone/
-  `declare function clone<T>(n: T): T;`,
-  `declare function cloneDeep<T>(n: T): T;`,
-  `declare function cloneDeepWithoutLoc<T>(n: T): T;`,
-  `declare function cloneNode<T>(n: T, deep?: boolean, withoutLoc?: boolean): T;`,
-  `declare function cloneWithoutLoc<T>(n: T): T;`,
+  `declare export function clone<T>(n: T): T;`,
+  `declare export function cloneDeep<T>(n: T): T;`,
+  `declare export function cloneDeepWithoutLoc<T>(n: T): T;`,
+  `declare export function cloneNode<T>(n: T, deep?: boolean, withoutLoc?: boolean): T;`,
+  `declare export function cloneWithoutLoc<T>(n: T): T;`,
 
   // comments/
   `declare type CommentTypeShorthand = 'leading' | 'inner' | 'trailing'`,
   // eslint-disable-next-line max-len
-  `declare function addComment<T: Node>(node: T, type: CommentTypeShorthand, content: string, line?: boolean): T`,
+  `declare export function addComment<T: BabelNode>(node: T, type: CommentTypeShorthand, content: string, line?: boolean): T`,
   // eslint-disable-next-line max-len
-  `declare function addComments<T: Node>(node: T, type: CommentTypeShorthand, comments: Array<Comment>): T`,
-  `declare function inheritInnerComments(node: Node, parent: Node): void`,
-  `declare function inheritLeadingComments(node: Node, parent: Node): void`,
-  `declare function inheritsComments<T: Node>(node: T, parent: Node): void`,
-  `declare function inheritTrailingComments(node: Node, parent: Node): void`,
-  `declare function removeComments<T: Node>(node: T): T`,
+  `declare export function addComments<T: BabelNode>(node: T, type: CommentTypeShorthand, comments: Array<Comment>): T`,
+  `declare export function inheritInnerComments(node: BabelNode, parent: BabelNode): void`,
+  `declare export function inheritLeadingComments(node: BabelNode, parent: BabelNode): void`,
+  `declare export function inheritsComments<T: BabelNode>(node: T, parent: BabelNode): void`,
+  `declare export function inheritTrailingComments(node: BabelNode, parent: BabelNode): void`,
+  `declare export function removeComments<T: BabelNode>(node: T): T`,
 
   // converters/
-  `declare function ensureBlock(node: ${NODE_PREFIX}, key: string): ${NODE_PREFIX}BlockStatement`,
-  `declare function toBindingIdentifierName(name?: ?string): string`,
+  `declare export function ensureBlock(node: ${NODE_PREFIX}, key: string): ${NODE_PREFIX}BlockStatement`,
+  `declare export function toBindingIdentifierName(name?: ?string): string`,
   // eslint-disable-next-line max-len
-  `declare function toBlock(node: ${NODE_PREFIX}Statement | ${NODE_PREFIX}Expression, parent?: ${NODE_PREFIX}Function | null): ${NODE_PREFIX}BlockStatement`,
+  `declare export function toBlock(node: ${NODE_PREFIX}Statement | ${NODE_PREFIX}Expression, parent?: ${NODE_PREFIX}Function | null): ${NODE_PREFIX}BlockStatement`,
   // eslint-disable-next-line max-len
-  `declare function toComputedKey(node: ${NODE_PREFIX}Method | ${NODE_PREFIX}Property, key?: ${NODE_PREFIX}Expression | ${NODE_PREFIX}Identifier): ${NODE_PREFIX}Expression`,
+  `declare export function toComputedKey(node: ${NODE_PREFIX}Method | ${NODE_PREFIX}Property, key?: ${NODE_PREFIX}Expression | ${NODE_PREFIX}Identifier): ${NODE_PREFIX}Expression`,
   // eslint-disable-next-line max-len
-  `declare function toExpression(node: ${NODE_PREFIX}ExpressionStatement | ${NODE_PREFIX}Expression | ${NODE_PREFIX}Class | ${NODE_PREFIX}Function): ${NODE_PREFIX}Expression`,
-  `declare function toIdentifier(name?: ?string): string`,
+  `declare export function toExpression(node: ${NODE_PREFIX}ExpressionStatement | ${NODE_PREFIX}Expression | ${NODE_PREFIX}Class | ${NODE_PREFIX}Function): ${NODE_PREFIX}Expression`,
+  `declare export function toIdentifier(name?: ?string): string`,
   // eslint-disable-next-line max-len
-  `declare function toKeyAlias(node: ${NODE_PREFIX}Method | ${NODE_PREFIX}Property, key?: ${NODE_PREFIX}): string`,
+  `declare export function toKeyAlias(node: ${NODE_PREFIX}Method | ${NODE_PREFIX}Property, key?: ${NODE_PREFIX}): string`,
   // toSequenceExpression relies on types that aren't declared in flow
   // eslint-disable-next-line max-len
-  `declare function toStatement(node: ${NODE_PREFIX}Statement | ${NODE_PREFIX}Class | ${NODE_PREFIX}Function | ${NODE_PREFIX}AssignmentExpression, ignore?: boolean): ${NODE_PREFIX}Statement | void`,
-  `declare function valueToNode(value: any): ${NODE_PREFIX}Expression`,
+  `declare export function toStatement(node: ${NODE_PREFIX}Statement | ${NODE_PREFIX}Class | ${NODE_PREFIX}Function | ${NODE_PREFIX}AssignmentExpression, ignore?: boolean): ${NODE_PREFIX}Statement | void`,
+  `declare export function valueToNode(value: any): ${NODE_PREFIX}Expression`,
 
   // modifications/
   // eslint-disable-next-line max-len
-  `declare function removeTypeDuplicates(types: Array<${NODE_PREFIX}FlowType>): Array<${NODE_PREFIX}FlowType>`,
+  `declare export function removeTypeDuplicates(types: Array<${NODE_PREFIX}FlowType>): Array<${NODE_PREFIX}FlowType>`,
   // eslint-disable-next-line max-len
-  `declare function appendToMemberExpression(member: ${NODE_PREFIX}MemberExpression, append: ${NODE_PREFIX}, computed?: boolean): ${NODE_PREFIX}MemberExpression`,
+  `declare export function appendToMemberExpression(member: ${NODE_PREFIX}MemberExpression, append: ${NODE_PREFIX}, computed?: boolean): ${NODE_PREFIX}MemberExpression`,
   // eslint-disable-next-line max-len
-  `declare function inherits<T: Node>(child: T, parent: ${NODE_PREFIX} | null | void): T`,
+  `declare export function inherits<T: BabelNode>(child: T, parent: ${NODE_PREFIX} | null | void): T`,
   // eslint-disable-next-line max-len
-  `declare function prependToMemberExpression(member: ${NODE_PREFIX}MemberExpression, prepend: ${NODE_PREFIX}Expression): ${NODE_PREFIX}MemberExpression`,
-  `declare function removeProperties<T>(n: T, opts: ?{}): void;`,
-  `declare function removePropertiesDeep<T>(n: T, opts: ?{}): T;`,
+  `declare export function prependToMemberExpression(member: ${NODE_PREFIX}MemberExpression, prepend: ${NODE_PREFIX}Expression): ${NODE_PREFIX}MemberExpression`,
+  `declare export function removeProperties<T>(n: T, opts: ?{}): void;`,
+  `declare export function removePropertiesDeep<T>(n: T, opts: ?{}): T;`,
 
   // retrievers/
   // eslint-disable-next-line max-len
-  `declare function getBindingIdentifiers(node: ${NODE_PREFIX}, duplicates: boolean, outerOnly?: boolean): { [key: string]: ${NODE_PREFIX}Identifier | Array<${NODE_PREFIX}Identifier> }`,
+  `declare export var getBindingIdentifiers: {
+    (node: ${NODE_PREFIX}, duplicates?: boolean, outerOnly?: boolean): { [key: string]: ${NODE_PREFIX}Identifier | Array<${NODE_PREFIX}Identifier> },
+    keys: { [type: string]: string[] }
+  }`,
   // eslint-disable-next-line max-len
-  `declare function getOuterBindingIdentifiers(node: Node, duplicates: boolean): { [key: string]: ${NODE_PREFIX}Identifier | Array<${NODE_PREFIX}Identifier> }`,
+  `declare export function getOuterBindingIdentifiers(node: BabelNode, duplicates?: boolean): { [key: string]: ${NODE_PREFIX}Identifier | Array<${NODE_PREFIX}Identifier> }`,
 
   // traverse/
   `declare type TraversalAncestors = Array<{
@@ -209,36 +214,36 @@ lines.push(
     exit?: TraversalHandler<T>,
   };`.replace(/(^|\n) {2}/g, "$1"),
   // eslint-disable-next-line
-  `declare function traverse<T>(n: BabelNode, TraversalHandler<T> | TraversalHandlers<T>, state?: T): void;`,
-  `declare function traverseFast<T>(n: Node, h: TraversalHandler<T>, state?: T): void;`,
+  `declare export function traverse<T>(n: BabelNode, TraversalHandler<T> | TraversalHandlers<T>, state?: T): void;`,
+  `declare export function traverseFast<T>(n: BabelNode, h: TraversalHandler<T>, state?: T): void;`,
 
   // utils/
   // cleanJSXElementLiteralChild is not exported
   // inherit is not exported
-  `declare function shallowEqual(actual: Object, expected: Object): boolean`,
+  `declare export function shallowEqual(actual: Object, expected: Object): boolean`,
 
   // validators/
   // eslint-disable-next-line max-len
-  `declare function buildMatchMemberExpression(match: string, allowPartial?: boolean): (?BabelNode) => boolean`,
-  `declare function is(type: string, n: BabelNode, opts: Object): boolean;`,
-  `declare function isBinding(node: BabelNode, parent: BabelNode, grandparent?: BabelNode): boolean`,
-  `declare function isBlockScoped(node: BabelNode): boolean`,
-  `declare function isImmutable(node: BabelNode): boolean`,
-  `declare function isLet(node: BabelNode): boolean`,
-  `declare function isNode(node: ?Object): boolean`,
-  `declare function isNodesEquivalent(a: any, b: any): boolean`,
-  `declare function isPlaceholderType(placeholderType: string, targetType: string): boolean`,
-  `declare function isReferenced(node: BabelNode, parent: BabelNode, grandparent?: BabelNode): boolean`,
-  `declare function isScope(node: BabelNode, parent: BabelNode): boolean`,
-  `declare function isSpecifierDefault(specifier: BabelNodeModuleSpecifier): boolean`,
-  `declare function isType(nodetype: ?string, targetType: string): boolean`,
-  `declare function isValidES3Identifier(name: string): boolean`,
-  `declare function isValidES3Identifier(name: string): boolean`,
-  `declare function isValidIdentifier(name: string): boolean`,
-  `declare function isVar(node: BabelNode): boolean`,
+  `declare export function buildMatchMemberExpression(match: string, allowPartial?: boolean): (?BabelNode) => boolean`,
+  `declare export function is(type: string, n: BabelNode, opts: Object): boolean;`,
+  `declare export function isBinding(node: BabelNode, parent: BabelNode, grandparent?: BabelNode): boolean`,
+  `declare export function isBlockScoped(node: BabelNode): boolean`,
+  `declare export function isImmutable(node: BabelNode): boolean`,
+  `declare export function isLet(node: BabelNode): boolean`,
+  `declare export function isNode(node: ?Object): boolean`,
+  `declare export function isNodesEquivalent(a: any, b: any): boolean`,
+  `declare export function isPlaceholderType(placeholderType: string, targetType: string): boolean`,
+  `declare export function isReferenced(node: BabelNode, parent: BabelNode, grandparent?: BabelNode): boolean`,
+  `declare export function isScope(node: BabelNode, parent: BabelNode): boolean`,
+  `declare export function isSpecifierDefault(specifier: BabelNodeModuleSpecifier): boolean`,
+  `declare export function isType(nodetype: ?string, targetType: string): boolean`,
+  `declare export function isValidES3Identifier(name: string): boolean`,
+  `declare export function isValidES3Identifier(name: string): boolean`,
+  `declare export function isValidIdentifier(name: string): boolean`,
+  `declare export function isVar(node: BabelNode): boolean`,
   // eslint-disable-next-line max-len
-  `declare function matchesPattern(node: ?BabelNode, match: string | Array<string>, allowPartial?: boolean): boolean`,
-  `declare function validate(n: BabelNode, key: string, value: mixed): void;`
+  `declare export function matchesPattern(node: ?BabelNode, match: string | Array<string>, allowPartial?: boolean): boolean`,
+  `declare export function validate(n: BabelNode, key: string, value: mixed): void;`
 );
 
 for (const type in t.FLIPPED_ALIAS_KEYS) {

--- a/packages/babel-types/scripts/generators/generateBuilders.js
+++ b/packages/babel-types/scripts/generators/generateBuilders.js
@@ -94,9 +94,7 @@ import type * as t from "../../types";\n\n`;
       formatedBuilderNameLocal === formatedBuilderName ? "export " : ""
     }function ${formatedBuilderNameLocal}(${defArgs.join(
       ", "
-    )}): t.${type} { return builder("${type}", ${callArgs.join(
-      ", "
-    )}); }\n`;
+    )}): t.${type} { return builder("${type}", ${callArgs.join(", ")}); }\n`;
     if (formatedBuilderNameLocal !== formatedBuilderName) {
       output += `export { ${formatedBuilderNameLocal} as ${formatedBuilderName} };\n`;
     }

--- a/packages/babel-types/src/builders/generated/index.ts
+++ b/packages/babel-types/src/builders/generated/index.ts
@@ -5,17 +5,19 @@
 import builder from "../builder";
 import type * as t from "../../types";
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 export function arrayExpression(
   elements?: Array<null | t.Expression | t.SpreadElement>,
 ): t.ArrayExpression {
-  return builder("ArrayExpression", elements);
+  return builder("ArrayExpression", ...arguments);
 }
 export function assignmentExpression(
   operator: string,
   left: t.LVal,
   right: t.Expression,
 ): t.AssignmentExpression {
-  return builder("AssignmentExpression", operator, left, right);
+  return builder("AssignmentExpression", ...arguments);
 }
 export function binaryExpression(
   operator:
@@ -44,25 +46,25 @@ export function binaryExpression(
   left: t.Expression | t.PrivateName,
   right: t.Expression,
 ): t.BinaryExpression {
-  return builder("BinaryExpression", operator, left, right);
+  return builder("BinaryExpression", ...arguments);
 }
 export function interpreterDirective(value: string): t.InterpreterDirective {
-  return builder("InterpreterDirective", value);
+  return builder("InterpreterDirective", ...arguments);
 }
 export function directive(value: t.DirectiveLiteral): t.Directive {
-  return builder("Directive", value);
+  return builder("Directive", ...arguments);
 }
 export function directiveLiteral(value: string): t.DirectiveLiteral {
-  return builder("DirectiveLiteral", value);
+  return builder("DirectiveLiteral", ...arguments);
 }
 export function blockStatement(
   body: Array<t.Statement>,
   directives?: Array<t.Directive>,
 ): t.BlockStatement {
-  return builder("BlockStatement", body, directives);
+  return builder("BlockStatement", ...arguments);
 }
 export function breakStatement(label?: t.Identifier | null): t.BreakStatement {
-  return builder("BreakStatement", label);
+  return builder("BreakStatement", ...arguments);
 }
 export function callExpression(
   callee: t.Expression | t.V8IntrinsicIdentifier,
@@ -70,56 +72,56 @@ export function callExpression(
     t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
   >,
 ): t.CallExpression {
-  return builder("CallExpression", callee, _arguments);
+  return builder("CallExpression", ...arguments);
 }
 export function catchClause(
   param: t.Identifier | t.ArrayPattern | t.ObjectPattern | null | undefined,
   body: t.BlockStatement,
 ): t.CatchClause {
-  return builder("CatchClause", param, body);
+  return builder("CatchClause", ...arguments);
 }
 export function conditionalExpression(
   test: t.Expression,
   consequent: t.Expression,
   alternate: t.Expression,
 ): t.ConditionalExpression {
-  return builder("ConditionalExpression", test, consequent, alternate);
+  return builder("ConditionalExpression", ...arguments);
 }
 export function continueStatement(
   label?: t.Identifier | null,
 ): t.ContinueStatement {
-  return builder("ContinueStatement", label);
+  return builder("ContinueStatement", ...arguments);
 }
 export function debuggerStatement(): t.DebuggerStatement {
-  return builder("DebuggerStatement");
+  return builder("DebuggerStatement", ...arguments);
 }
 export function doWhileStatement(
   test: t.Expression,
   body: t.Statement,
 ): t.DoWhileStatement {
-  return builder("DoWhileStatement", test, body);
+  return builder("DoWhileStatement", ...arguments);
 }
 export function emptyStatement(): t.EmptyStatement {
-  return builder("EmptyStatement");
+  return builder("EmptyStatement", ...arguments);
 }
 export function expressionStatement(
   expression: t.Expression,
 ): t.ExpressionStatement {
-  return builder("ExpressionStatement", expression);
+  return builder("ExpressionStatement", ...arguments);
 }
 export function file(
   program: t.Program,
   comments?: Array<t.CommentBlock | t.CommentLine> | null,
   tokens?: Array<any> | null,
 ): t.File {
-  return builder("File", program, comments, tokens);
+  return builder("File", ...arguments);
 }
 export function forInStatement(
   left: t.VariableDeclaration | t.LVal,
   right: t.Expression,
   body: t.Statement,
 ): t.ForInStatement {
-  return builder("ForInStatement", left, right, body);
+  return builder("ForInStatement", ...arguments);
 }
 export function forStatement(
   init: t.VariableDeclaration | t.Expression | null | undefined,
@@ -127,7 +129,7 @@ export function forStatement(
   update: t.Expression | null | undefined,
   body: t.Statement,
 ): t.ForStatement {
-  return builder("ForStatement", init, test, update, body);
+  return builder("ForStatement", ...arguments);
 }
 export function functionDeclaration(
   id: t.Identifier | null | undefined,
@@ -138,7 +140,7 @@ export function functionDeclaration(
   generator?: boolean,
   async?: boolean,
 ): t.FunctionDeclaration {
-  return builder("FunctionDeclaration", id, params, body, generator, async);
+  return builder("FunctionDeclaration", ...arguments);
 }
 export function functionExpression(
   id: t.Identifier | null | undefined,
@@ -149,48 +151,48 @@ export function functionExpression(
   generator?: boolean,
   async?: boolean,
 ): t.FunctionExpression {
-  return builder("FunctionExpression", id, params, body, generator, async);
+  return builder("FunctionExpression", ...arguments);
 }
 export function identifier(name: string): t.Identifier {
-  return builder("Identifier", name);
+  return builder("Identifier", ...arguments);
 }
 export function ifStatement(
   test: t.Expression,
   consequent: t.Statement,
   alternate?: t.Statement | null,
 ): t.IfStatement {
-  return builder("IfStatement", test, consequent, alternate);
+  return builder("IfStatement", ...arguments);
 }
 export function labeledStatement(
   label: t.Identifier,
   body: t.Statement,
 ): t.LabeledStatement {
-  return builder("LabeledStatement", label, body);
+  return builder("LabeledStatement", ...arguments);
 }
 export function stringLiteral(value: string): t.StringLiteral {
-  return builder("StringLiteral", value);
+  return builder("StringLiteral", ...arguments);
 }
 export function numericLiteral(value: number): t.NumericLiteral {
-  return builder("NumericLiteral", value);
+  return builder("NumericLiteral", ...arguments);
 }
 export function nullLiteral(): t.NullLiteral {
-  return builder("NullLiteral");
+  return builder("NullLiteral", ...arguments);
 }
 export function booleanLiteral(value: boolean): t.BooleanLiteral {
-  return builder("BooleanLiteral", value);
+  return builder("BooleanLiteral", ...arguments);
 }
 export function regExpLiteral(
   pattern: string,
   flags?: string,
 ): t.RegExpLiteral {
-  return builder("RegExpLiteral", pattern, flags);
+  return builder("RegExpLiteral", ...arguments);
 }
 export function logicalExpression(
   operator: "||" | "&&" | "??",
   left: t.Expression,
   right: t.Expression,
 ): t.LogicalExpression {
-  return builder("LogicalExpression", operator, left, right);
+  return builder("LogicalExpression", ...arguments);
 }
 export function memberExpression(
   object: t.Expression,
@@ -198,7 +200,7 @@ export function memberExpression(
   computed?: boolean,
   optional?: true | false | null,
 ): t.MemberExpression {
-  return builder("MemberExpression", object, property, computed, optional);
+  return builder("MemberExpression", ...arguments);
 }
 export function newExpression(
   callee: t.Expression | t.V8IntrinsicIdentifier,
@@ -206,7 +208,7 @@ export function newExpression(
     t.Expression | t.SpreadElement | t.JSXNamespacedName | t.ArgumentPlaceholder
   >,
 ): t.NewExpression {
-  return builder("NewExpression", callee, _arguments);
+  return builder("NewExpression", ...arguments);
 }
 export function program(
   body: Array<t.Statement>,
@@ -214,12 +216,12 @@ export function program(
   sourceType?: "script" | "module",
   interpreter?: t.InterpreterDirective | null,
 ): t.Program {
-  return builder("Program", body, directives, sourceType, interpreter);
+  return builder("Program", ...arguments);
 }
 export function objectExpression(
   properties: Array<t.ObjectMethod | t.ObjectProperty | t.SpreadElement>,
 ): t.ObjectExpression {
-  return builder("ObjectExpression", properties);
+  return builder("ObjectExpression", ...arguments);
 }
 export function objectMethod(
   kind: "method" | "get" | "set" | undefined,
@@ -232,16 +234,7 @@ export function objectMethod(
   generator?: boolean,
   async?: boolean,
 ): t.ObjectMethod {
-  return builder(
-    "ObjectMethod",
-    kind,
-    key,
-    params,
-    body,
-    computed,
-    generator,
-    async,
-  );
+  return builder("ObjectMethod", ...arguments);
 }
 export function objectProperty(
   key: t.Expression | t.Identifier | t.StringLiteral | t.NumericLiteral,
@@ -250,99 +243,99 @@ export function objectProperty(
   shorthand?: boolean,
   decorators?: Array<t.Decorator> | null,
 ): t.ObjectProperty {
-  return builder("ObjectProperty", key, value, computed, shorthand, decorators);
+  return builder("ObjectProperty", ...arguments);
 }
 export function restElement(argument: t.LVal): t.RestElement {
-  return builder("RestElement", argument);
+  return builder("RestElement", ...arguments);
 }
 export function returnStatement(
   argument?: t.Expression | null,
 ): t.ReturnStatement {
-  return builder("ReturnStatement", argument);
+  return builder("ReturnStatement", ...arguments);
 }
 export function sequenceExpression(
   expressions: Array<t.Expression>,
 ): t.SequenceExpression {
-  return builder("SequenceExpression", expressions);
+  return builder("SequenceExpression", ...arguments);
 }
 export function parenthesizedExpression(
   expression: t.Expression,
 ): t.ParenthesizedExpression {
-  return builder("ParenthesizedExpression", expression);
+  return builder("ParenthesizedExpression", ...arguments);
 }
 export function switchCase(
   test: t.Expression | null | undefined,
   consequent: Array<t.Statement>,
 ): t.SwitchCase {
-  return builder("SwitchCase", test, consequent);
+  return builder("SwitchCase", ...arguments);
 }
 export function switchStatement(
   discriminant: t.Expression,
   cases: Array<t.SwitchCase>,
 ): t.SwitchStatement {
-  return builder("SwitchStatement", discriminant, cases);
+  return builder("SwitchStatement", ...arguments);
 }
 export function thisExpression(): t.ThisExpression {
-  return builder("ThisExpression");
+  return builder("ThisExpression", ...arguments);
 }
 export function throwStatement(argument: t.Expression): t.ThrowStatement {
-  return builder("ThrowStatement", argument);
+  return builder("ThrowStatement", ...arguments);
 }
 export function tryStatement(
   block: t.BlockStatement,
   handler?: t.CatchClause | null,
   finalizer?: t.BlockStatement | null,
 ): t.TryStatement {
-  return builder("TryStatement", block, handler, finalizer);
+  return builder("TryStatement", ...arguments);
 }
 export function unaryExpression(
   operator: "void" | "throw" | "delete" | "!" | "+" | "-" | "~" | "typeof",
   argument: t.Expression,
   prefix?: boolean,
 ): t.UnaryExpression {
-  return builder("UnaryExpression", operator, argument, prefix);
+  return builder("UnaryExpression", ...arguments);
 }
 export function updateExpression(
   operator: "++" | "--",
   argument: t.Expression,
   prefix?: boolean,
 ): t.UpdateExpression {
-  return builder("UpdateExpression", operator, argument, prefix);
+  return builder("UpdateExpression", ...arguments);
 }
 export function variableDeclaration(
   kind: "var" | "let" | "const",
   declarations: Array<t.VariableDeclarator>,
 ): t.VariableDeclaration {
-  return builder("VariableDeclaration", kind, declarations);
+  return builder("VariableDeclaration", ...arguments);
 }
 export function variableDeclarator(
   id: t.LVal,
   init?: t.Expression | null,
 ): t.VariableDeclarator {
-  return builder("VariableDeclarator", id, init);
+  return builder("VariableDeclarator", ...arguments);
 }
 export function whileStatement(
   test: t.Expression,
   body: t.Statement,
 ): t.WhileStatement {
-  return builder("WhileStatement", test, body);
+  return builder("WhileStatement", ...arguments);
 }
 export function withStatement(
   object: t.Expression,
   body: t.Statement,
 ): t.WithStatement {
-  return builder("WithStatement", object, body);
+  return builder("WithStatement", ...arguments);
 }
 export function assignmentPattern(
   left: t.Identifier | t.ObjectPattern | t.ArrayPattern | t.MemberExpression,
   right: t.Expression,
 ): t.AssignmentPattern {
-  return builder("AssignmentPattern", left, right);
+  return builder("AssignmentPattern", ...arguments);
 }
 export function arrayPattern(
   elements: Array<null | t.PatternLike>,
 ): t.ArrayPattern {
-  return builder("ArrayPattern", elements);
+  return builder("ArrayPattern", ...arguments);
 }
 export function arrowFunctionExpression(
   params: Array<
@@ -351,7 +344,7 @@ export function arrowFunctionExpression(
   body: t.BlockStatement | t.Expression,
   async?: boolean,
 ): t.ArrowFunctionExpression {
-  return builder("ArrowFunctionExpression", params, body, async);
+  return builder("ArrowFunctionExpression", ...arguments);
 }
 export function classBody(
   body: Array<
@@ -363,7 +356,7 @@ export function classBody(
     | t.TSIndexSignature
   >,
 ): t.ClassBody {
-  return builder("ClassBody", body);
+  return builder("ClassBody", ...arguments);
 }
 export function classExpression(
   id: t.Identifier | null | undefined,
@@ -371,7 +364,7 @@ export function classExpression(
   body: t.ClassBody,
   decorators?: Array<t.Decorator> | null,
 ): t.ClassExpression {
-  return builder("ClassExpression", id, superClass, body, decorators);
+  return builder("ClassExpression", ...arguments);
 }
 export function classDeclaration(
   id: t.Identifier,
@@ -379,12 +372,12 @@ export function classDeclaration(
   body: t.ClassBody,
   decorators?: Array<t.Decorator> | null,
 ): t.ClassDeclaration {
-  return builder("ClassDeclaration", id, superClass, body, decorators);
+  return builder("ClassDeclaration", ...arguments);
 }
 export function exportAllDeclaration(
   source: t.StringLiteral,
 ): t.ExportAllDeclaration {
-  return builder("ExportAllDeclaration", source);
+  return builder("ExportAllDeclaration", ...arguments);
 }
 export function exportDefaultDeclaration(
   declaration:
@@ -393,7 +386,7 @@ export function exportDefaultDeclaration(
     | t.ClassDeclaration
     | t.Expression,
 ): t.ExportDefaultDeclaration {
-  return builder("ExportDefaultDeclaration", declaration);
+  return builder("ExportDefaultDeclaration", ...arguments);
 }
 export function exportNamedDeclaration(
   declaration?: t.Declaration | null,
@@ -402,13 +395,13 @@ export function exportNamedDeclaration(
   >,
   source?: t.StringLiteral | null,
 ): t.ExportNamedDeclaration {
-  return builder("ExportNamedDeclaration", declaration, specifiers, source);
+  return builder("ExportNamedDeclaration", ...arguments);
 }
 export function exportSpecifier(
   local: t.Identifier,
   exported: t.Identifier | t.StringLiteral,
 ): t.ExportSpecifier {
-  return builder("ExportSpecifier", local, exported);
+  return builder("ExportSpecifier", ...arguments);
 }
 export function forOfStatement(
   left: t.VariableDeclaration | t.LVal,
@@ -416,7 +409,7 @@ export function forOfStatement(
   body: t.Statement,
   _await?: boolean,
 ): t.ForOfStatement {
-  return builder("ForOfStatement", left, right, body, _await);
+  return builder("ForOfStatement", ...arguments);
 }
 export function importDeclaration(
   specifiers: Array<
@@ -424,29 +417,29 @@ export function importDeclaration(
   >,
   source: t.StringLiteral,
 ): t.ImportDeclaration {
-  return builder("ImportDeclaration", specifiers, source);
+  return builder("ImportDeclaration", ...arguments);
 }
 export function importDefaultSpecifier(
   local: t.Identifier,
 ): t.ImportDefaultSpecifier {
-  return builder("ImportDefaultSpecifier", local);
+  return builder("ImportDefaultSpecifier", ...arguments);
 }
 export function importNamespaceSpecifier(
   local: t.Identifier,
 ): t.ImportNamespaceSpecifier {
-  return builder("ImportNamespaceSpecifier", local);
+  return builder("ImportNamespaceSpecifier", ...arguments);
 }
 export function importSpecifier(
   local: t.Identifier,
   imported: t.Identifier | t.StringLiteral,
 ): t.ImportSpecifier {
-  return builder("ImportSpecifier", local, imported);
+  return builder("ImportSpecifier", ...arguments);
 }
 export function metaProperty(
   meta: t.Identifier,
   property: t.Identifier,
 ): t.MetaProperty {
-  return builder("MetaProperty", meta, property);
+  return builder("MetaProperty", ...arguments);
 }
 export function classMethod(
   kind: "get" | "set" | "method" | "constructor" | undefined,
@@ -460,68 +453,58 @@ export function classMethod(
   generator?: boolean,
   async?: boolean,
 ): t.ClassMethod {
-  return builder(
-    "ClassMethod",
-    kind,
-    key,
-    params,
-    body,
-    computed,
-    _static,
-    generator,
-    async,
-  );
+  return builder("ClassMethod", ...arguments);
 }
 export function objectPattern(
   properties: Array<t.RestElement | t.ObjectProperty>,
 ): t.ObjectPattern {
-  return builder("ObjectPattern", properties);
+  return builder("ObjectPattern", ...arguments);
 }
 export function spreadElement(argument: t.Expression): t.SpreadElement {
-  return builder("SpreadElement", argument);
+  return builder("SpreadElement", ...arguments);
 }
 function _super(): t.Super {
-  return builder("Super");
+  return builder("Super", ...arguments);
 }
 export { _super as super };
 export function taggedTemplateExpression(
   tag: t.Expression,
   quasi: t.TemplateLiteral,
 ): t.TaggedTemplateExpression {
-  return builder("TaggedTemplateExpression", tag, quasi);
+  return builder("TaggedTemplateExpression", ...arguments);
 }
 export function templateElement(
   value: { raw: string; cooked?: string },
   tail?: boolean,
 ): t.TemplateElement {
-  return builder("TemplateElement", value, tail);
+  return builder("TemplateElement", ...arguments);
 }
 export function templateLiteral(
   quasis: Array<t.TemplateElement>,
   expressions: Array<t.Expression | t.TSType>,
 ): t.TemplateLiteral {
-  return builder("TemplateLiteral", quasis, expressions);
+  return builder("TemplateLiteral", ...arguments);
 }
 export function yieldExpression(
   argument?: t.Expression | null,
   delegate?: boolean,
 ): t.YieldExpression {
-  return builder("YieldExpression", argument, delegate);
+  return builder("YieldExpression", ...arguments);
 }
 export function awaitExpression(argument: t.Expression): t.AwaitExpression {
-  return builder("AwaitExpression", argument);
+  return builder("AwaitExpression", ...arguments);
 }
 function _import(): t.Import {
-  return builder("Import");
+  return builder("Import", ...arguments);
 }
 export { _import as import };
 export function bigIntLiteral(value: string): t.BigIntLiteral {
-  return builder("BigIntLiteral", value);
+  return builder("BigIntLiteral", ...arguments);
 }
 export function exportNamespaceSpecifier(
   exported: t.Identifier,
 ): t.ExportNamespaceSpecifier {
-  return builder("ExportNamespaceSpecifier", exported);
+  return builder("ExportNamespaceSpecifier", ...arguments);
 }
 export function optionalMemberExpression(
   object: t.Expression,
@@ -529,13 +512,7 @@ export function optionalMemberExpression(
   computed: boolean | undefined,
   optional: boolean,
 ): t.OptionalMemberExpression {
-  return builder(
-    "OptionalMemberExpression",
-    object,
-    property,
-    computed,
-    optional,
-  );
+  return builder("OptionalMemberExpression", ...arguments);
 }
 export function optionalCallExpression(
   callee: t.Expression,
@@ -544,32 +521,32 @@ export function optionalCallExpression(
   >,
   optional: boolean,
 ): t.OptionalCallExpression {
-  return builder("OptionalCallExpression", callee, _arguments, optional);
+  return builder("OptionalCallExpression", ...arguments);
 }
 export function anyTypeAnnotation(): t.AnyTypeAnnotation {
-  return builder("AnyTypeAnnotation");
+  return builder("AnyTypeAnnotation", ...arguments);
 }
 export function arrayTypeAnnotation(
   elementType: t.FlowType,
 ): t.ArrayTypeAnnotation {
-  return builder("ArrayTypeAnnotation", elementType);
+  return builder("ArrayTypeAnnotation", ...arguments);
 }
 export function booleanTypeAnnotation(): t.BooleanTypeAnnotation {
-  return builder("BooleanTypeAnnotation");
+  return builder("BooleanTypeAnnotation", ...arguments);
 }
 export function booleanLiteralTypeAnnotation(
   value: boolean,
 ): t.BooleanLiteralTypeAnnotation {
-  return builder("BooleanLiteralTypeAnnotation", value);
+  return builder("BooleanLiteralTypeAnnotation", ...arguments);
 }
 export function nullLiteralTypeAnnotation(): t.NullLiteralTypeAnnotation {
-  return builder("NullLiteralTypeAnnotation");
+  return builder("NullLiteralTypeAnnotation", ...arguments);
 }
 export function classImplements(
   id: t.Identifier,
   typeParameters?: t.TypeParameterInstantiation | null,
 ): t.ClassImplements {
-  return builder("ClassImplements", id, typeParameters);
+  return builder("ClassImplements", ...arguments);
 }
 export function declareClass(
   id: t.Identifier,
@@ -577,10 +554,10 @@ export function declareClass(
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
 ): t.DeclareClass {
-  return builder("DeclareClass", id, typeParameters, _extends, body);
+  return builder("DeclareClass", ...arguments);
 }
 export function declareFunction(id: t.Identifier): t.DeclareFunction {
-  return builder("DeclareFunction", id);
+  return builder("DeclareFunction", ...arguments);
 }
 export function declareInterface(
   id: t.Identifier,
@@ -588,54 +565,54 @@ export function declareInterface(
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
 ): t.DeclareInterface {
-  return builder("DeclareInterface", id, typeParameters, _extends, body);
+  return builder("DeclareInterface", ...arguments);
 }
 export function declareModule(
   id: t.Identifier | t.StringLiteral,
   body: t.BlockStatement,
   kind?: "CommonJS" | "ES" | null,
 ): t.DeclareModule {
-  return builder("DeclareModule", id, body, kind);
+  return builder("DeclareModule", ...arguments);
 }
 export function declareModuleExports(
   typeAnnotation: t.TypeAnnotation,
 ): t.DeclareModuleExports {
-  return builder("DeclareModuleExports", typeAnnotation);
+  return builder("DeclareModuleExports", ...arguments);
 }
 export function declareTypeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   right: t.FlowType,
 ): t.DeclareTypeAlias {
-  return builder("DeclareTypeAlias", id, typeParameters, right);
+  return builder("DeclareTypeAlias", ...arguments);
 }
 export function declareOpaqueType(
   id: t.Identifier,
   typeParameters?: t.TypeParameterDeclaration | null,
   supertype?: t.FlowType | null,
 ): t.DeclareOpaqueType {
-  return builder("DeclareOpaqueType", id, typeParameters, supertype);
+  return builder("DeclareOpaqueType", ...arguments);
 }
 export function declareVariable(id: t.Identifier): t.DeclareVariable {
-  return builder("DeclareVariable", id);
+  return builder("DeclareVariable", ...arguments);
 }
 export function declareExportDeclaration(
   declaration?: t.Flow | null,
   specifiers?: Array<t.ExportSpecifier | t.ExportNamespaceSpecifier> | null,
   source?: t.StringLiteral | null,
 ): t.DeclareExportDeclaration {
-  return builder("DeclareExportDeclaration", declaration, specifiers, source);
+  return builder("DeclareExportDeclaration", ...arguments);
 }
 export function declareExportAllDeclaration(
   source: t.StringLiteral,
 ): t.DeclareExportAllDeclaration {
-  return builder("DeclareExportAllDeclaration", source);
+  return builder("DeclareExportAllDeclaration", ...arguments);
 }
 export function declaredPredicate(value: t.Flow): t.DeclaredPredicate {
-  return builder("DeclaredPredicate", value);
+  return builder("DeclaredPredicate", ...arguments);
 }
 export function existsTypeAnnotation(): t.ExistsTypeAnnotation {
-  return builder("ExistsTypeAnnotation");
+  return builder("ExistsTypeAnnotation", ...arguments);
 }
 export function functionTypeAnnotation(
   typeParameters: t.TypeParameterDeclaration | null | undefined,
@@ -643,34 +620,28 @@ export function functionTypeAnnotation(
   rest: t.FunctionTypeParam | null | undefined,
   returnType: t.FlowType,
 ): t.FunctionTypeAnnotation {
-  return builder(
-    "FunctionTypeAnnotation",
-    typeParameters,
-    params,
-    rest,
-    returnType,
-  );
+  return builder("FunctionTypeAnnotation", ...arguments);
 }
 export function functionTypeParam(
   name: t.Identifier | null | undefined,
   typeAnnotation: t.FlowType,
 ): t.FunctionTypeParam {
-  return builder("FunctionTypeParam", name, typeAnnotation);
+  return builder("FunctionTypeParam", ...arguments);
 }
 export function genericTypeAnnotation(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters?: t.TypeParameterInstantiation | null,
 ): t.GenericTypeAnnotation {
-  return builder("GenericTypeAnnotation", id, typeParameters);
+  return builder("GenericTypeAnnotation", ...arguments);
 }
 export function inferredPredicate(): t.InferredPredicate {
-  return builder("InferredPredicate");
+  return builder("InferredPredicate", ...arguments);
 }
 export function interfaceExtends(
   id: t.Identifier | t.QualifiedTypeIdentifier,
   typeParameters?: t.TypeParameterInstantiation | null,
 ): t.InterfaceExtends {
-  return builder("InterfaceExtends", id, typeParameters);
+  return builder("InterfaceExtends", ...arguments);
 }
 export function interfaceDeclaration(
   id: t.Identifier,
@@ -678,37 +649,37 @@ export function interfaceDeclaration(
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
 ): t.InterfaceDeclaration {
-  return builder("InterfaceDeclaration", id, typeParameters, _extends, body);
+  return builder("InterfaceDeclaration", ...arguments);
 }
 export function interfaceTypeAnnotation(
   _extends: Array<t.InterfaceExtends> | null | undefined,
   body: t.ObjectTypeAnnotation,
 ): t.InterfaceTypeAnnotation {
-  return builder("InterfaceTypeAnnotation", _extends, body);
+  return builder("InterfaceTypeAnnotation", ...arguments);
 }
 export function intersectionTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.IntersectionTypeAnnotation {
-  return builder("IntersectionTypeAnnotation", types);
+  return builder("IntersectionTypeAnnotation", ...arguments);
 }
 export function mixedTypeAnnotation(): t.MixedTypeAnnotation {
-  return builder("MixedTypeAnnotation");
+  return builder("MixedTypeAnnotation", ...arguments);
 }
 export function emptyTypeAnnotation(): t.EmptyTypeAnnotation {
-  return builder("EmptyTypeAnnotation");
+  return builder("EmptyTypeAnnotation", ...arguments);
 }
 export function nullableTypeAnnotation(
   typeAnnotation: t.FlowType,
 ): t.NullableTypeAnnotation {
-  return builder("NullableTypeAnnotation", typeAnnotation);
+  return builder("NullableTypeAnnotation", ...arguments);
 }
 export function numberLiteralTypeAnnotation(
   value: number,
 ): t.NumberLiteralTypeAnnotation {
-  return builder("NumberLiteralTypeAnnotation", value);
+  return builder("NumberLiteralTypeAnnotation", ...arguments);
 }
 export function numberTypeAnnotation(): t.NumberTypeAnnotation {
-  return builder("NumberTypeAnnotation");
+  return builder("NumberTypeAnnotation", ...arguments);
 }
 export function objectTypeAnnotation(
   properties: Array<t.ObjectTypeProperty | t.ObjectTypeSpreadProperty>,
@@ -717,14 +688,7 @@ export function objectTypeAnnotation(
   internalSlots?: Array<t.ObjectTypeInternalSlot> | null,
   exact?: boolean,
 ): t.ObjectTypeAnnotation {
-  return builder(
-    "ObjectTypeAnnotation",
-    properties,
-    indexers,
-    callProperties,
-    internalSlots,
-    exact,
-  );
+  return builder("ObjectTypeAnnotation", ...arguments);
 }
 export function objectTypeInternalSlot(
   id: t.Identifier,
@@ -733,19 +697,12 @@ export function objectTypeInternalSlot(
   _static: boolean,
   method: boolean,
 ): t.ObjectTypeInternalSlot {
-  return builder(
-    "ObjectTypeInternalSlot",
-    id,
-    value,
-    optional,
-    _static,
-    method,
-  );
+  return builder("ObjectTypeInternalSlot", ...arguments);
 }
 export function objectTypeCallProperty(
   value: t.FlowType,
 ): t.ObjectTypeCallProperty {
-  return builder("ObjectTypeCallProperty", value);
+  return builder("ObjectTypeCallProperty", ...arguments);
 }
 export function objectTypeIndexer(
   id: t.Identifier | null | undefined,
@@ -753,19 +710,19 @@ export function objectTypeIndexer(
   value: t.FlowType,
   variance?: t.Variance | null,
 ): t.ObjectTypeIndexer {
-  return builder("ObjectTypeIndexer", id, key, value, variance);
+  return builder("ObjectTypeIndexer", ...arguments);
 }
 export function objectTypeProperty(
   key: t.Identifier | t.StringLiteral,
   value: t.FlowType,
   variance?: t.Variance | null,
 ): t.ObjectTypeProperty {
-  return builder("ObjectTypeProperty", key, value, variance);
+  return builder("ObjectTypeProperty", ...arguments);
 }
 export function objectTypeSpreadProperty(
   argument: t.FlowType,
 ): t.ObjectTypeSpreadProperty {
-  return builder("ObjectTypeSpreadProperty", argument);
+  return builder("ObjectTypeSpreadProperty", ...arguments);
 }
 export function opaqueType(
   id: t.Identifier,
@@ -773,81 +730,81 @@ export function opaqueType(
   supertype: t.FlowType | null | undefined,
   impltype: t.FlowType,
 ): t.OpaqueType {
-  return builder("OpaqueType", id, typeParameters, supertype, impltype);
+  return builder("OpaqueType", ...arguments);
 }
 export function qualifiedTypeIdentifier(
   id: t.Identifier,
   qualification: t.Identifier | t.QualifiedTypeIdentifier,
 ): t.QualifiedTypeIdentifier {
-  return builder("QualifiedTypeIdentifier", id, qualification);
+  return builder("QualifiedTypeIdentifier", ...arguments);
 }
 export function stringLiteralTypeAnnotation(
   value: string,
 ): t.StringLiteralTypeAnnotation {
-  return builder("StringLiteralTypeAnnotation", value);
+  return builder("StringLiteralTypeAnnotation", ...arguments);
 }
 export function stringTypeAnnotation(): t.StringTypeAnnotation {
-  return builder("StringTypeAnnotation");
+  return builder("StringTypeAnnotation", ...arguments);
 }
 export function symbolTypeAnnotation(): t.SymbolTypeAnnotation {
-  return builder("SymbolTypeAnnotation");
+  return builder("SymbolTypeAnnotation", ...arguments);
 }
 export function thisTypeAnnotation(): t.ThisTypeAnnotation {
-  return builder("ThisTypeAnnotation");
+  return builder("ThisTypeAnnotation", ...arguments);
 }
 export function tupleTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.TupleTypeAnnotation {
-  return builder("TupleTypeAnnotation", types);
+  return builder("TupleTypeAnnotation", ...arguments);
 }
 export function typeofTypeAnnotation(
   argument: t.FlowType,
 ): t.TypeofTypeAnnotation {
-  return builder("TypeofTypeAnnotation", argument);
+  return builder("TypeofTypeAnnotation", ...arguments);
 }
 export function typeAlias(
   id: t.Identifier,
   typeParameters: t.TypeParameterDeclaration | null | undefined,
   right: t.FlowType,
 ): t.TypeAlias {
-  return builder("TypeAlias", id, typeParameters, right);
+  return builder("TypeAlias", ...arguments);
 }
 export function typeAnnotation(typeAnnotation: t.FlowType): t.TypeAnnotation {
-  return builder("TypeAnnotation", typeAnnotation);
+  return builder("TypeAnnotation", ...arguments);
 }
 export function typeCastExpression(
   expression: t.Expression,
   typeAnnotation: t.TypeAnnotation,
 ): t.TypeCastExpression {
-  return builder("TypeCastExpression", expression, typeAnnotation);
+  return builder("TypeCastExpression", ...arguments);
 }
 export function typeParameter(
   bound?: t.TypeAnnotation | null,
   _default?: t.FlowType | null,
   variance?: t.Variance | null,
 ): t.TypeParameter {
-  return builder("TypeParameter", bound, _default, variance);
+  return builder("TypeParameter", ...arguments);
 }
 export function typeParameterDeclaration(
   params: Array<t.TypeParameter>,
 ): t.TypeParameterDeclaration {
-  return builder("TypeParameterDeclaration", params);
+  return builder("TypeParameterDeclaration", ...arguments);
 }
 export function typeParameterInstantiation(
   params: Array<t.FlowType>,
 ): t.TypeParameterInstantiation {
-  return builder("TypeParameterInstantiation", params);
+  return builder("TypeParameterInstantiation", ...arguments);
 }
 export function unionTypeAnnotation(
   types: Array<t.FlowType>,
 ): t.UnionTypeAnnotation {
-  return builder("UnionTypeAnnotation", types);
+  return builder("UnionTypeAnnotation", ...arguments);
 }
 export function variance(kind: "minus" | "plus"): t.Variance {
-  return builder("Variance", kind);
+  return builder("Variance", ...arguments);
 }
 export function voidTypeAnnotation(): t.VoidTypeAnnotation {
-  return builder("VoidTypeAnnotation");
+  return builder("VoidTypeAnnotation", ...arguments);
 }
 export function enumDeclaration(
   id: t.Identifier,
@@ -857,45 +814,45 @@ export function enumDeclaration(
     | t.EnumStringBody
     | t.EnumSymbolBody,
 ): t.EnumDeclaration {
-  return builder("EnumDeclaration", id, body);
+  return builder("EnumDeclaration", ...arguments);
 }
 export function enumBooleanBody(
   members: Array<t.EnumBooleanMember>,
 ): t.EnumBooleanBody {
-  return builder("EnumBooleanBody", members);
+  return builder("EnumBooleanBody", ...arguments);
 }
 export function enumNumberBody(
   members: Array<t.EnumNumberMember>,
 ): t.EnumNumberBody {
-  return builder("EnumNumberBody", members);
+  return builder("EnumNumberBody", ...arguments);
 }
 export function enumStringBody(
   members: Array<t.EnumStringMember | t.EnumDefaultedMember>,
 ): t.EnumStringBody {
-  return builder("EnumStringBody", members);
+  return builder("EnumStringBody", ...arguments);
 }
 export function enumSymbolBody(
   members: Array<t.EnumDefaultedMember>,
 ): t.EnumSymbolBody {
-  return builder("EnumSymbolBody", members);
+  return builder("EnumSymbolBody", ...arguments);
 }
 export function enumBooleanMember(id: t.Identifier): t.EnumBooleanMember {
-  return builder("EnumBooleanMember", id);
+  return builder("EnumBooleanMember", ...arguments);
 }
 export function enumNumberMember(
   id: t.Identifier,
   init: t.NumericLiteral,
 ): t.EnumNumberMember {
-  return builder("EnumNumberMember", id, init);
+  return builder("EnumNumberMember", ...arguments);
 }
 export function enumStringMember(
   id: t.Identifier,
   init: t.StringLiteral,
 ): t.EnumStringMember {
-  return builder("EnumStringMember", id, init);
+  return builder("EnumStringMember", ...arguments);
 }
 export function enumDefaultedMember(id: t.Identifier): t.EnumDefaultedMember {
-  return builder("EnumDefaultedMember", id);
+  return builder("EnumDefaultedMember", ...arguments);
 }
 export function jsxAttribute(
   name: t.JSXIdentifier | t.JSXNamespacedName,
@@ -906,13 +863,13 @@ export function jsxAttribute(
     | t.JSXExpressionContainer
     | null,
 ): t.JSXAttribute {
-  return builder("JSXAttribute", name, value);
+  return builder("JSXAttribute", ...arguments);
 }
 export { jsxAttribute as jSXAttribute };
 export function jsxClosingElement(
   name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
 ): t.JSXClosingElement {
-  return builder("JSXClosingElement", name);
+  return builder("JSXClosingElement", ...arguments);
 }
 export { jsxClosingElement as jSXClosingElement };
 export function jsxElement(
@@ -927,45 +884,39 @@ export function jsxElement(
   >,
   selfClosing?: boolean | null,
 ): t.JSXElement {
-  return builder(
-    "JSXElement",
-    openingElement,
-    closingElement,
-    children,
-    selfClosing,
-  );
+  return builder("JSXElement", ...arguments);
 }
 export { jsxElement as jSXElement };
 export function jsxEmptyExpression(): t.JSXEmptyExpression {
-  return builder("JSXEmptyExpression");
+  return builder("JSXEmptyExpression", ...arguments);
 }
 export { jsxEmptyExpression as jSXEmptyExpression };
 export function jsxExpressionContainer(
   expression: t.Expression | t.JSXEmptyExpression,
 ): t.JSXExpressionContainer {
-  return builder("JSXExpressionContainer", expression);
+  return builder("JSXExpressionContainer", ...arguments);
 }
 export { jsxExpressionContainer as jSXExpressionContainer };
 export function jsxSpreadChild(expression: t.Expression): t.JSXSpreadChild {
-  return builder("JSXSpreadChild", expression);
+  return builder("JSXSpreadChild", ...arguments);
 }
 export { jsxSpreadChild as jSXSpreadChild };
 export function jsxIdentifier(name: string): t.JSXIdentifier {
-  return builder("JSXIdentifier", name);
+  return builder("JSXIdentifier", ...arguments);
 }
 export { jsxIdentifier as jSXIdentifier };
 export function jsxMemberExpression(
   object: t.JSXMemberExpression | t.JSXIdentifier,
   property: t.JSXIdentifier,
 ): t.JSXMemberExpression {
-  return builder("JSXMemberExpression", object, property);
+  return builder("JSXMemberExpression", ...arguments);
 }
 export { jsxMemberExpression as jSXMemberExpression };
 export function jsxNamespacedName(
   namespace: t.JSXIdentifier,
   name: t.JSXIdentifier,
 ): t.JSXNamespacedName {
-  return builder("JSXNamespacedName", namespace, name);
+  return builder("JSXNamespacedName", ...arguments);
 }
 export { jsxNamespacedName as jSXNamespacedName };
 export function jsxOpeningElement(
@@ -973,17 +924,17 @@ export function jsxOpeningElement(
   attributes: Array<t.JSXAttribute | t.JSXSpreadAttribute>,
   selfClosing?: boolean,
 ): t.JSXOpeningElement {
-  return builder("JSXOpeningElement", name, attributes, selfClosing);
+  return builder("JSXOpeningElement", ...arguments);
 }
 export { jsxOpeningElement as jSXOpeningElement };
 export function jsxSpreadAttribute(
   argument: t.Expression,
 ): t.JSXSpreadAttribute {
-  return builder("JSXSpreadAttribute", argument);
+  return builder("JSXSpreadAttribute", ...arguments);
 }
 export { jsxSpreadAttribute as jSXSpreadAttribute };
 export function jsxText(value: string): t.JSXText {
-  return builder("JSXText", value);
+  return builder("JSXText", ...arguments);
 }
 export { jsxText as jSXText };
 export function jsxFragment(
@@ -997,19 +948,19 @@ export function jsxFragment(
     | t.JSXFragment
   >,
 ): t.JSXFragment {
-  return builder("JSXFragment", openingFragment, closingFragment, children);
+  return builder("JSXFragment", ...arguments);
 }
 export { jsxFragment as jSXFragment };
 export function jsxOpeningFragment(): t.JSXOpeningFragment {
-  return builder("JSXOpeningFragment");
+  return builder("JSXOpeningFragment", ...arguments);
 }
 export { jsxOpeningFragment as jSXOpeningFragment };
 export function jsxClosingFragment(): t.JSXClosingFragment {
-  return builder("JSXClosingFragment");
+  return builder("JSXClosingFragment", ...arguments);
 }
 export { jsxClosingFragment as jSXClosingFragment };
 export function noop(): t.Noop {
-  return builder("Noop");
+  return builder("Noop", ...arguments);
 }
 export function placeholder(
   expectedNode:
@@ -1023,19 +974,19 @@ export function placeholder(
     | "Pattern",
   name: t.Identifier,
 ): t.Placeholder {
-  return builder("Placeholder", expectedNode, name);
+  return builder("Placeholder", ...arguments);
 }
 export function v8IntrinsicIdentifier(name: string): t.V8IntrinsicIdentifier {
-  return builder("V8IntrinsicIdentifier", name);
+  return builder("V8IntrinsicIdentifier", ...arguments);
 }
 export function argumentPlaceholder(): t.ArgumentPlaceholder {
-  return builder("ArgumentPlaceholder");
+  return builder("ArgumentPlaceholder", ...arguments);
 }
 export function bindExpression(
   object: t.Expression,
   callee: t.Expression,
 ): t.BindExpression {
-  return builder("BindExpression", object, callee);
+  return builder("BindExpression", ...arguments);
 }
 export function classProperty(
   key: t.Identifier | t.StringLiteral | t.NumericLiteral | t.Expression,
@@ -1045,28 +996,20 @@ export function classProperty(
   computed?: boolean,
   _static?: boolean,
 ): t.ClassProperty {
-  return builder(
-    "ClassProperty",
-    key,
-    value,
-    typeAnnotation,
-    decorators,
-    computed,
-    _static,
-  );
+  return builder("ClassProperty", ...arguments);
 }
 export function pipelineTopicExpression(
   expression: t.Expression,
 ): t.PipelineTopicExpression {
-  return builder("PipelineTopicExpression", expression);
+  return builder("PipelineTopicExpression", ...arguments);
 }
 export function pipelineBareFunction(
   callee: t.Expression,
 ): t.PipelineBareFunction {
-  return builder("PipelineBareFunction", callee);
+  return builder("PipelineBareFunction", ...arguments);
 }
 export function pipelinePrimaryTopicReference(): t.PipelinePrimaryTopicReference {
-  return builder("PipelinePrimaryTopicReference");
+  return builder("PipelinePrimaryTopicReference", ...arguments);
 }
 export function classPrivateProperty(
   key: t.PrivateName,
@@ -1074,7 +1017,7 @@ export function classPrivateProperty(
   decorators: Array<t.Decorator> | null | undefined,
   _static: any,
 ): t.ClassPrivateProperty {
-  return builder("ClassPrivateProperty", key, value, decorators, _static);
+  return builder("ClassPrivateProperty", ...arguments);
 }
 export function classPrivateMethod(
   kind: "get" | "set" | "method" | "constructor" | undefined,
@@ -1085,48 +1028,48 @@ export function classPrivateMethod(
   body: t.BlockStatement,
   _static?: boolean,
 ): t.ClassPrivateMethod {
-  return builder("ClassPrivateMethod", kind, key, params, body, _static);
+  return builder("ClassPrivateMethod", ...arguments);
 }
 export function importAttribute(
   key: t.Identifier | t.StringLiteral,
   value: t.StringLiteral,
 ): t.ImportAttribute {
-  return builder("ImportAttribute", key, value);
+  return builder("ImportAttribute", ...arguments);
 }
 export function decorator(expression: t.Expression): t.Decorator {
-  return builder("Decorator", expression);
+  return builder("Decorator", ...arguments);
 }
 export function doExpression(body: t.BlockStatement): t.DoExpression {
-  return builder("DoExpression", body);
+  return builder("DoExpression", ...arguments);
 }
 export function exportDefaultSpecifier(
   exported: t.Identifier,
 ): t.ExportDefaultSpecifier {
-  return builder("ExportDefaultSpecifier", exported);
+  return builder("ExportDefaultSpecifier", ...arguments);
 }
 export function privateName(id: t.Identifier): t.PrivateName {
-  return builder("PrivateName", id);
+  return builder("PrivateName", ...arguments);
 }
 export function recordExpression(
   properties: Array<t.ObjectProperty | t.SpreadElement>,
 ): t.RecordExpression {
-  return builder("RecordExpression", properties);
+  return builder("RecordExpression", ...arguments);
 }
 export function tupleExpression(
   elements?: Array<t.Expression | t.SpreadElement>,
 ): t.TupleExpression {
-  return builder("TupleExpression", elements);
+  return builder("TupleExpression", ...arguments);
 }
 export function decimalLiteral(value: string): t.DecimalLiteral {
-  return builder("DecimalLiteral", value);
+  return builder("DecimalLiteral", ...arguments);
 }
 export function staticBlock(body: Array<t.Statement>): t.StaticBlock {
-  return builder("StaticBlock", body);
+  return builder("StaticBlock", ...arguments);
 }
 export function tsParameterProperty(
   parameter: t.Identifier | t.AssignmentPattern,
 ): t.TSParameterProperty {
-  return builder("TSParameterProperty", parameter);
+  return builder("TSParameterProperty", ...arguments);
 }
 export { tsParameterProperty as tSParameterProperty };
 export function tsDeclareFunction(
@@ -1137,7 +1080,7 @@ export function tsDeclareFunction(
   >,
   returnType?: t.TSTypeAnnotation | t.Noop | null,
 ): t.TSDeclareFunction {
-  return builder("TSDeclareFunction", id, typeParameters, params, returnType);
+  return builder("TSDeclareFunction", ...arguments);
 }
 export { tsDeclareFunction as tSDeclareFunction };
 export function tsDeclareMethod(
@@ -1149,21 +1092,14 @@ export function tsDeclareMethod(
   >,
   returnType?: t.TSTypeAnnotation | t.Noop | null,
 ): t.TSDeclareMethod {
-  return builder(
-    "TSDeclareMethod",
-    decorators,
-    key,
-    typeParameters,
-    params,
-    returnType,
-  );
+  return builder("TSDeclareMethod", ...arguments);
 }
 export { tsDeclareMethod as tSDeclareMethod };
 export function tsQualifiedName(
   left: t.TSEntityName,
   right: t.Identifier,
 ): t.TSQualifiedName {
-  return builder("TSQualifiedName", left, right);
+  return builder("TSQualifiedName", ...arguments);
 }
 export { tsQualifiedName as tSQualifiedName };
 export function tsCallSignatureDeclaration(
@@ -1171,12 +1107,7 @@ export function tsCallSignatureDeclaration(
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
 ): t.TSCallSignatureDeclaration {
-  return builder(
-    "TSCallSignatureDeclaration",
-    typeParameters,
-    parameters,
-    typeAnnotation,
-  );
+  return builder("TSCallSignatureDeclaration", ...arguments);
 }
 export { tsCallSignatureDeclaration as tSCallSignatureDeclaration };
 export function tsConstructSignatureDeclaration(
@@ -1184,12 +1115,7 @@ export function tsConstructSignatureDeclaration(
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
 ): t.TSConstructSignatureDeclaration {
-  return builder(
-    "TSConstructSignatureDeclaration",
-    typeParameters,
-    parameters,
-    typeAnnotation,
-  );
+  return builder("TSConstructSignatureDeclaration", ...arguments);
 }
 export { tsConstructSignatureDeclaration as tSConstructSignatureDeclaration };
 export function tsPropertySignature(
@@ -1197,7 +1123,7 @@ export function tsPropertySignature(
   typeAnnotation?: t.TSTypeAnnotation | null,
   initializer?: t.Expression | null,
 ): t.TSPropertySignature {
-  return builder("TSPropertySignature", key, typeAnnotation, initializer);
+  return builder("TSPropertySignature", ...arguments);
 }
 export { tsPropertySignature as tSPropertySignature };
 export function tsMethodSignature(
@@ -1206,76 +1132,70 @@ export function tsMethodSignature(
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
 ): t.TSMethodSignature {
-  return builder(
-    "TSMethodSignature",
-    key,
-    typeParameters,
-    parameters,
-    typeAnnotation,
-  );
+  return builder("TSMethodSignature", ...arguments);
 }
 export { tsMethodSignature as tSMethodSignature };
 export function tsIndexSignature(
   parameters: Array<t.Identifier>,
   typeAnnotation?: t.TSTypeAnnotation | null,
 ): t.TSIndexSignature {
-  return builder("TSIndexSignature", parameters, typeAnnotation);
+  return builder("TSIndexSignature", ...arguments);
 }
 export { tsIndexSignature as tSIndexSignature };
 export function tsAnyKeyword(): t.TSAnyKeyword {
-  return builder("TSAnyKeyword");
+  return builder("TSAnyKeyword", ...arguments);
 }
 export { tsAnyKeyword as tSAnyKeyword };
 export function tsBooleanKeyword(): t.TSBooleanKeyword {
-  return builder("TSBooleanKeyword");
+  return builder("TSBooleanKeyword", ...arguments);
 }
 export { tsBooleanKeyword as tSBooleanKeyword };
 export function tsBigIntKeyword(): t.TSBigIntKeyword {
-  return builder("TSBigIntKeyword");
+  return builder("TSBigIntKeyword", ...arguments);
 }
 export { tsBigIntKeyword as tSBigIntKeyword };
 export function tsIntrinsicKeyword(): t.TSIntrinsicKeyword {
-  return builder("TSIntrinsicKeyword");
+  return builder("TSIntrinsicKeyword", ...arguments);
 }
 export { tsIntrinsicKeyword as tSIntrinsicKeyword };
 export function tsNeverKeyword(): t.TSNeverKeyword {
-  return builder("TSNeverKeyword");
+  return builder("TSNeverKeyword", ...arguments);
 }
 export { tsNeverKeyword as tSNeverKeyword };
 export function tsNullKeyword(): t.TSNullKeyword {
-  return builder("TSNullKeyword");
+  return builder("TSNullKeyword", ...arguments);
 }
 export { tsNullKeyword as tSNullKeyword };
 export function tsNumberKeyword(): t.TSNumberKeyword {
-  return builder("TSNumberKeyword");
+  return builder("TSNumberKeyword", ...arguments);
 }
 export { tsNumberKeyword as tSNumberKeyword };
 export function tsObjectKeyword(): t.TSObjectKeyword {
-  return builder("TSObjectKeyword");
+  return builder("TSObjectKeyword", ...arguments);
 }
 export { tsObjectKeyword as tSObjectKeyword };
 export function tsStringKeyword(): t.TSStringKeyword {
-  return builder("TSStringKeyword");
+  return builder("TSStringKeyword", ...arguments);
 }
 export { tsStringKeyword as tSStringKeyword };
 export function tsSymbolKeyword(): t.TSSymbolKeyword {
-  return builder("TSSymbolKeyword");
+  return builder("TSSymbolKeyword", ...arguments);
 }
 export { tsSymbolKeyword as tSSymbolKeyword };
 export function tsUndefinedKeyword(): t.TSUndefinedKeyword {
-  return builder("TSUndefinedKeyword");
+  return builder("TSUndefinedKeyword", ...arguments);
 }
 export { tsUndefinedKeyword as tSUndefinedKeyword };
 export function tsUnknownKeyword(): t.TSUnknownKeyword {
-  return builder("TSUnknownKeyword");
+  return builder("TSUnknownKeyword", ...arguments);
 }
 export { tsUnknownKeyword as tSUnknownKeyword };
 export function tsVoidKeyword(): t.TSVoidKeyword {
-  return builder("TSVoidKeyword");
+  return builder("TSVoidKeyword", ...arguments);
 }
 export { tsVoidKeyword as tSVoidKeyword };
 export function tsThisType(): t.TSThisType {
-  return builder("TSThisType");
+  return builder("TSThisType", ...arguments);
 }
 export { tsThisType as tSThisType };
 export function tsFunctionType(
@@ -1283,7 +1203,7 @@ export function tsFunctionType(
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
 ): t.TSFunctionType {
-  return builder("TSFunctionType", typeParameters, parameters, typeAnnotation);
+  return builder("TSFunctionType", ...arguments);
 }
 export { tsFunctionType as tSFunctionType };
 export function tsConstructorType(
@@ -1291,19 +1211,14 @@ export function tsConstructorType(
   parameters: Array<t.Identifier | t.RestElement>,
   typeAnnotation?: t.TSTypeAnnotation | null,
 ): t.TSConstructorType {
-  return builder(
-    "TSConstructorType",
-    typeParameters,
-    parameters,
-    typeAnnotation,
-  );
+  return builder("TSConstructorType", ...arguments);
 }
 export { tsConstructorType as tSConstructorType };
 export function tsTypeReference(
   typeName: t.TSEntityName,
   typeParameters?: t.TSTypeParameterInstantiation | null,
 ): t.TSTypeReference {
-  return builder("TSTypeReference", typeName, typeParameters);
+  return builder("TSTypeReference", ...arguments);
 }
 export { tsTypeReference as tSTypeReference };
 export function tsTypePredicate(
@@ -1311,37 +1226,37 @@ export function tsTypePredicate(
   typeAnnotation?: t.TSTypeAnnotation | null,
   asserts?: boolean | null,
 ): t.TSTypePredicate {
-  return builder("TSTypePredicate", parameterName, typeAnnotation, asserts);
+  return builder("TSTypePredicate", ...arguments);
 }
 export { tsTypePredicate as tSTypePredicate };
 export function tsTypeQuery(
   exprName: t.TSEntityName | t.TSImportType,
 ): t.TSTypeQuery {
-  return builder("TSTypeQuery", exprName);
+  return builder("TSTypeQuery", ...arguments);
 }
 export { tsTypeQuery as tSTypeQuery };
 export function tsTypeLiteral(
   members: Array<t.TSTypeElement>,
 ): t.TSTypeLiteral {
-  return builder("TSTypeLiteral", members);
+  return builder("TSTypeLiteral", ...arguments);
 }
 export { tsTypeLiteral as tSTypeLiteral };
 export function tsArrayType(elementType: t.TSType): t.TSArrayType {
-  return builder("TSArrayType", elementType);
+  return builder("TSArrayType", ...arguments);
 }
 export { tsArrayType as tSArrayType };
 export function tsTupleType(
   elementTypes: Array<t.TSType | t.TSNamedTupleMember>,
 ): t.TSTupleType {
-  return builder("TSTupleType", elementTypes);
+  return builder("TSTupleType", ...arguments);
 }
 export { tsTupleType as tSTupleType };
 export function tsOptionalType(typeAnnotation: t.TSType): t.TSOptionalType {
-  return builder("TSOptionalType", typeAnnotation);
+  return builder("TSOptionalType", ...arguments);
 }
 export { tsOptionalType as tSOptionalType };
 export function tsRestType(typeAnnotation: t.TSType): t.TSRestType {
-  return builder("TSRestType", typeAnnotation);
+  return builder("TSRestType", ...arguments);
 }
 export { tsRestType as tSRestType };
 export function tsNamedTupleMember(
@@ -1349,17 +1264,17 @@ export function tsNamedTupleMember(
   elementType: t.TSType,
   optional?: boolean,
 ): t.TSNamedTupleMember {
-  return builder("TSNamedTupleMember", label, elementType, optional);
+  return builder("TSNamedTupleMember", ...arguments);
 }
 export { tsNamedTupleMember as tSNamedTupleMember };
 export function tsUnionType(types: Array<t.TSType>): t.TSUnionType {
-  return builder("TSUnionType", types);
+  return builder("TSUnionType", ...arguments);
 }
 export { tsUnionType as tSUnionType };
 export function tsIntersectionType(
   types: Array<t.TSType>,
 ): t.TSIntersectionType {
-  return builder("TSIntersectionType", types);
+  return builder("TSIntersectionType", ...arguments);
 }
 export { tsIntersectionType as tSIntersectionType };
 export function tsConditionalType(
@@ -1368,34 +1283,28 @@ export function tsConditionalType(
   trueType: t.TSType,
   falseType: t.TSType,
 ): t.TSConditionalType {
-  return builder(
-    "TSConditionalType",
-    checkType,
-    extendsType,
-    trueType,
-    falseType,
-  );
+  return builder("TSConditionalType", ...arguments);
 }
 export { tsConditionalType as tSConditionalType };
 export function tsInferType(typeParameter: t.TSTypeParameter): t.TSInferType {
-  return builder("TSInferType", typeParameter);
+  return builder("TSInferType", ...arguments);
 }
 export { tsInferType as tSInferType };
 export function tsParenthesizedType(
   typeAnnotation: t.TSType,
 ): t.TSParenthesizedType {
-  return builder("TSParenthesizedType", typeAnnotation);
+  return builder("TSParenthesizedType", ...arguments);
 }
 export { tsParenthesizedType as tSParenthesizedType };
 export function tsTypeOperator(typeAnnotation: t.TSType): t.TSTypeOperator {
-  return builder("TSTypeOperator", typeAnnotation);
+  return builder("TSTypeOperator", ...arguments);
 }
 export { tsTypeOperator as tSTypeOperator };
 export function tsIndexedAccessType(
   objectType: t.TSType,
   indexType: t.TSType,
 ): t.TSIndexedAccessType {
-  return builder("TSIndexedAccessType", objectType, indexType);
+  return builder("TSIndexedAccessType", ...arguments);
 }
 export { tsIndexedAccessType as tSIndexedAccessType };
 export function tsMappedType(
@@ -1403,7 +1312,7 @@ export function tsMappedType(
   typeAnnotation?: t.TSType | null,
   nameType?: t.TSType | null,
 ): t.TSMappedType {
-  return builder("TSMappedType", typeParameter, typeAnnotation, nameType);
+  return builder("TSMappedType", ...arguments);
 }
 export { tsMappedType as tSMappedType };
 export function tsLiteralType(
@@ -1413,14 +1322,14 @@ export function tsLiteralType(
     | t.BooleanLiteral
     | t.BigIntLiteral,
 ): t.TSLiteralType {
-  return builder("TSLiteralType", literal);
+  return builder("TSLiteralType", ...arguments);
 }
 export { tsLiteralType as tSLiteralType };
 export function tsExpressionWithTypeArguments(
   expression: t.TSEntityName,
   typeParameters?: t.TSTypeParameterInstantiation | null,
 ): t.TSExpressionWithTypeArguments {
-  return builder("TSExpressionWithTypeArguments", expression, typeParameters);
+  return builder("TSExpressionWithTypeArguments", ...arguments);
 }
 export { tsExpressionWithTypeArguments as tSExpressionWithTypeArguments };
 export function tsInterfaceDeclaration(
@@ -1429,13 +1338,13 @@ export function tsInterfaceDeclaration(
   _extends: Array<t.TSExpressionWithTypeArguments> | null | undefined,
   body: t.TSInterfaceBody,
 ): t.TSInterfaceDeclaration {
-  return builder("TSInterfaceDeclaration", id, typeParameters, _extends, body);
+  return builder("TSInterfaceDeclaration", ...arguments);
 }
 export { tsInterfaceDeclaration as tSInterfaceDeclaration };
 export function tsInterfaceBody(
   body: Array<t.TSTypeElement>,
 ): t.TSInterfaceBody {
-  return builder("TSInterfaceBody", body);
+  return builder("TSInterfaceBody", ...arguments);
 }
 export { tsInterfaceBody as tSInterfaceBody };
 export function tsTypeAliasDeclaration(
@@ -1443,46 +1352,46 @@ export function tsTypeAliasDeclaration(
   typeParameters: t.TSTypeParameterDeclaration | null | undefined,
   typeAnnotation: t.TSType,
 ): t.TSTypeAliasDeclaration {
-  return builder("TSTypeAliasDeclaration", id, typeParameters, typeAnnotation);
+  return builder("TSTypeAliasDeclaration", ...arguments);
 }
 export { tsTypeAliasDeclaration as tSTypeAliasDeclaration };
 export function tsAsExpression(
   expression: t.Expression,
   typeAnnotation: t.TSType,
 ): t.TSAsExpression {
-  return builder("TSAsExpression", expression, typeAnnotation);
+  return builder("TSAsExpression", ...arguments);
 }
 export { tsAsExpression as tSAsExpression };
 export function tsTypeAssertion(
   typeAnnotation: t.TSType,
   expression: t.Expression,
 ): t.TSTypeAssertion {
-  return builder("TSTypeAssertion", typeAnnotation, expression);
+  return builder("TSTypeAssertion", ...arguments);
 }
 export { tsTypeAssertion as tSTypeAssertion };
 export function tsEnumDeclaration(
   id: t.Identifier,
   members: Array<t.TSEnumMember>,
 ): t.TSEnumDeclaration {
-  return builder("TSEnumDeclaration", id, members);
+  return builder("TSEnumDeclaration", ...arguments);
 }
 export { tsEnumDeclaration as tSEnumDeclaration };
 export function tsEnumMember(
   id: t.Identifier | t.StringLiteral,
   initializer?: t.Expression | null,
 ): t.TSEnumMember {
-  return builder("TSEnumMember", id, initializer);
+  return builder("TSEnumMember", ...arguments);
 }
 export { tsEnumMember as tSEnumMember };
 export function tsModuleDeclaration(
   id: t.Identifier | t.StringLiteral,
   body: t.TSModuleBlock | t.TSModuleDeclaration,
 ): t.TSModuleDeclaration {
-  return builder("TSModuleDeclaration", id, body);
+  return builder("TSModuleDeclaration", ...arguments);
 }
 export { tsModuleDeclaration as tSModuleDeclaration };
 export function tsModuleBlock(body: Array<t.Statement>): t.TSModuleBlock {
-  return builder("TSModuleBlock", body);
+  return builder("TSModuleBlock", ...arguments);
 }
 export { tsModuleBlock as tSModuleBlock };
 export function tsImportType(
@@ -1490,54 +1399,54 @@ export function tsImportType(
   qualifier?: t.TSEntityName | null,
   typeParameters?: t.TSTypeParameterInstantiation | null,
 ): t.TSImportType {
-  return builder("TSImportType", argument, qualifier, typeParameters);
+  return builder("TSImportType", ...arguments);
 }
 export { tsImportType as tSImportType };
 export function tsImportEqualsDeclaration(
   id: t.Identifier,
   moduleReference: t.TSEntityName | t.TSExternalModuleReference,
 ): t.TSImportEqualsDeclaration {
-  return builder("TSImportEqualsDeclaration", id, moduleReference);
+  return builder("TSImportEqualsDeclaration", ...arguments);
 }
 export { tsImportEqualsDeclaration as tSImportEqualsDeclaration };
 export function tsExternalModuleReference(
   expression: t.StringLiteral,
 ): t.TSExternalModuleReference {
-  return builder("TSExternalModuleReference", expression);
+  return builder("TSExternalModuleReference", ...arguments);
 }
 export { tsExternalModuleReference as tSExternalModuleReference };
 export function tsNonNullExpression(
   expression: t.Expression,
 ): t.TSNonNullExpression {
-  return builder("TSNonNullExpression", expression);
+  return builder("TSNonNullExpression", ...arguments);
 }
 export { tsNonNullExpression as tSNonNullExpression };
 export function tsExportAssignment(
   expression: t.Expression,
 ): t.TSExportAssignment {
-  return builder("TSExportAssignment", expression);
+  return builder("TSExportAssignment", ...arguments);
 }
 export { tsExportAssignment as tSExportAssignment };
 export function tsNamespaceExportDeclaration(
   id: t.Identifier,
 ): t.TSNamespaceExportDeclaration {
-  return builder("TSNamespaceExportDeclaration", id);
+  return builder("TSNamespaceExportDeclaration", ...arguments);
 }
 export { tsNamespaceExportDeclaration as tSNamespaceExportDeclaration };
 export function tsTypeAnnotation(typeAnnotation: t.TSType): t.TSTypeAnnotation {
-  return builder("TSTypeAnnotation", typeAnnotation);
+  return builder("TSTypeAnnotation", ...arguments);
 }
 export { tsTypeAnnotation as tSTypeAnnotation };
 export function tsTypeParameterInstantiation(
   params: Array<t.TSType>,
 ): t.TSTypeParameterInstantiation {
-  return builder("TSTypeParameterInstantiation", params);
+  return builder("TSTypeParameterInstantiation", ...arguments);
 }
 export { tsTypeParameterInstantiation as tSTypeParameterInstantiation };
 export function tsTypeParameterDeclaration(
   params: Array<t.TSTypeParameter>,
 ): t.TSTypeParameterDeclaration {
-  return builder("TSTypeParameterDeclaration", params);
+  return builder("TSTypeParameterDeclaration", ...arguments);
 }
 export { tsTypeParameterDeclaration as tSTypeParameterDeclaration };
 export function tsTypeParameter(
@@ -1545,7 +1454,7 @@ export function tsTypeParameter(
   _default: t.TSType | null | undefined,
   name: string,
 ): t.TSTypeParameter {
-  return builder("TSTypeParameter", constraint, _default, name);
+  return builder("TSTypeParameter", ...arguments);
 }
 export { tsTypeParameter as tSTypeParameter };
 /** @deprecated */

--- a/scripts/lint-ts-typings.sh
+++ b/scripts/lint-ts-typings.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-tsFlags="--strict"
-
-yarn tsc $tsFlags ./packages/babel-types/lib/index.d.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,6 +3385,7 @@ __metadata:
     "@babel/generator": "workspace:*"
     "@babel/helper-validator-identifier": "workspace:^7.10.4"
     "@babel/parser": "workspace:*"
+    "@types/lodash": ^4.14.162
     chalk: ^4.1.0
     lodash: ^4.17.19
     to-fast-properties: ^2.0.0
@@ -3901,6 +3902,13 @@ __metadata:
   version: 0.0.29
   resolution: "@types/json5@npm:0.0.29"
   checksum: 66e9ac0143ec521522c7bb670301e9836ee886207eeed1aab6d4854a1b19b404ab3a54cd8d449f9b1f13acc357f540be96f8ac2d1e86e301eab52ae0f9a4066f
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4.14.162":
+  version: 4.14.165
+  resolution: "@types/lodash@npm:4.14.165"
+  checksum: 525bfc34b0b591cc957125a961c70e63e5ad8b23cbd89b7594a5ea74823285b6d96993a7eec506e26b379ee52dc9dcd3a894ff210be4c97bccb536e62361dbc8
   languageName: node
   linkType: hard
 
@@ -4840,6 +4848,7 @@ __metadata:
     mergeiterator: ^1.2.5
     prettier: ^2.0.5
     rollup: ^2.26.5
+    rollup-plugin-dts: ^2.0.0
     rollup-plugin-node-polyfills: ^0.2.1
     rollup-plugin-terser: ^7.0.0
     test262-stream: ^1.3.0
@@ -9714,7 +9723,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.25.2, magic-string@npm:^0.25.3, magic-string@npm:^0.25.5":
+"magic-string@npm:^0.25.2, magic-string@npm:^0.25.3, magic-string@npm:^0.25.5, magic-string@npm:^0.25.7":
   version: 0.25.7
   resolution: "magic-string@npm:0.25.7"
   dependencies:
@@ -11707,6 +11716,22 @@ fsevents@^1.2.7:
     hash-base: ^3.0.0
     inherits: ^2.0.1
   checksum: e0370fbe779b1f15d74c3e7dffc0ce40b57b845fc7e431fab8a571958d5fd9c91eb0038a252604600e20786d117badea0cc4cf8816b8a6be6b9166b565ad6797
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-dts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "rollup-plugin-dts@npm:2.0.0"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    magic-string: ^0.25.7
+  peerDependencies:
+    rollup: ^2.33.3
+    typescript: ^4.1.2
+  dependenciesMeta:
+    "@babel/code-frame":
+      optional: true
+  checksum: 858dea6359da9fd3926311f22591b51f4cd29669ab63a8556ff25eede91f2461107eec74b1d25447f9343243e21cc9091f924941baa4c9e1700ecbe4bdbe3d43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/main/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->

The first commit fixes handling of `.d.ts` files on publish.

Rather than not running `make tscheck` to avoid accidental `.d.ts` files in published package, with this  PR we:
1. Run `make tscheck` to type-check and generate `.d.ts` files
2. Run `gulp bundle-dts` to generate a single `.d.ts` file for the packages we care about. This avoid problems when someone using TS depends on `@babel/types`, and TS "accidentally" emits a reference to an _internal_ `@babell/types/lib/**/*.d.ts` file (as explained at point 8 of [this article by Rob Palmer](https://www.techatbloomberg.com/blog/10-insights-adopting-typescript-at-scale/))
3. Run `gulp clean-dts`, to delete `.d.ts` files we don't want to publish.

This commit probably depends on https://github.com/babel/babel/pull/12420/files#discussion_r536288735

---

The second commit fixes a bug with the `@babel/types` flow generation: we didn't catch it earlier because Flow was using `src/index.js` rather than `lib/index.js.flow`.